### PR TITLE
⬆️ Bump Laravel version to 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "license": "MIT",
     "require": {
         "php" : ">=7.0.0",
-        "illuminate/support": "^5.8|^6.0|^7.0",
-        "illuminate/database": "^5.8|^6.0|^7.0",
-        "illuminate/view": "^5.8|^6.0|^7.0"
+        "illuminate/support": "^5.8|^6.0|^7.0|^8.0",
+        "illuminate/database": "^5.8|^6.0|^7.0|^8.0",
+        "illuminate/view": "^5.8|^6.0|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR aims to bump the Laravel dependency to 8.x

There isn't much breaking changes that affects this package. For more info, please see [Laravel 8.x Upgrade Guide](https://laravel.com/docs/8.x/upgrade).